### PR TITLE
Fix typo and formatting in comments (third-class -> third-party)

### DIFF
--- a/engram_demo_v1.py
+++ b/engram_demo_v1.py
@@ -27,7 +27,7 @@ from typing import List
 from dataclasses import dataclass, field
 import math
 
-## third-class
+## third-party
 from sympy import isprime
 import numpy as np
 import torch
@@ -324,7 +324,7 @@ class MultiHeadEmbedding(nn.Module):
         return output
     
 class Engram(nn.Module):
-    def __init__(self,layer_id):
+    def __init__(self, layer_id):
         super().__init__()
         self.layer_id = layer_id
         self.hash_mapping = NgramHashMapping(


### PR DESCRIPTION
After investigation, I found that "third-class" means "inferior" or "low-quality" in English, which was likely intended to be "third-party" (referring to external libraries). I also noticed some PEP 8 spacing issues (missing spaces after commas in function signatures and calls). I've fixed one as an example. If there are more issues that need to be addressed, please let me know — I'm happy to fix them!